### PR TITLE
pointer-events fix

### DIFF
--- a/bookmarklet.d/40-goggles.js
+++ b/bookmarklet.d/40-goggles.js
@@ -8,7 +8,8 @@ function Goggles(ajaxroot) {
     position: "fixed",
     "z-index": "100000",
     top: "0",
-    left: "0"
+    left: "0",
+    "pointer-events": "auto"
   }).appendTo(document.body)[0];
 
   this.url = getUrl();


### PR DESCRIPTION
Facepunch.com has pointer-events: none; on all canvas elements which prevents Goggles from working. This should fix it.
